### PR TITLE
Extend Leblender Grid Converter to render with typed grid view

### DIFF
--- a/Config/GridEditorLeBlenderConfig.cs
+++ b/Config/GridEditorLeBlenderConfig.cs
@@ -1,0 +1,60 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Skybrud.Umbraco.GridData;
+using Skybrud.Umbraco.GridData.Extensions.Json;
+using Skybrud.Umbraco.GridData.Interfaces;
+using Skybrud.Umbraco.GridData.Json;
+
+namespace Opten.Umbraco.GridData.Config
+{
+    public class GridEditorLeBlenderConfig : GridJsonObject, IGridEditorConfig
+	{
+		#region Properties
+
+
+        [JsonProperty("renderInGrid", NullValueHandling = NullValueHandling.Ignore)]
+        public string RenderInGrid { get; private set; }
+
+
+		[JsonProperty("frontView", NullValueHandling = NullValueHandling.Ignore)]
+        public string FrontView { get; private set; }
+
+        public GridEditor Editor { get; private set; }
+
+        public string Guid { get; private set; }
+
+
+		#endregion
+
+		#region Constructors
+
+        private GridEditorLeBlenderConfig(GridEditor editor, JObject obj)
+            : base(obj)
+        {
+            Editor = editor;
+            JToken guidJToken;
+            if ((guidJToken = editor.Control.JObject.GetValue("guid")) != null)
+            {
+                Guid = guidJToken.Value<string>();
+            }
+            
+        }
+
+		#endregion
+
+		#region Static methods
+
+
+        public static GridEditorLeBlenderConfig Parse(GridEditor editor, JObject obj)
+		{
+            if (obj == null) return null;
+            return new GridEditorLeBlenderConfig(editor, obj)
+            {
+                FrontView = obj.GetString("frontView"),
+                RenderInGrid = obj.GetString("renderInGrid")
+            };
+		}
+		
+		#endregion
+	}
+}

--- a/Converters/LeBlenderGridConverter.cs
+++ b/Converters/LeBlenderGridConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Lecoati.LeBlender.Extension.Models;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Opten.Umbraco.GridData.Values;
 using Skybrud.Umbraco.GridData.Interfaces;
 using System;
@@ -7,28 +8,61 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Skybrud.Umbraco.GridData.Extensions.Json;
+using Skybrud.Umbraco.GridData;
+using Skybrud.Umbraco.GridData.Rendering;
+using Opten.Umbraco.GridData.Config;
 
 namespace Opten.Umbraco.GridData.Converters
 {
 	public class LeBlenderGridConverter : IGridConverter
 	{
-		public bool ConvertControlValue(Skybrud.Umbraco.GridData.GridControl control, Newtonsoft.Json.Linq.JToken token, out IGridControlValue value)
+		public bool ConvertControlValue(GridControl control, Newtonsoft.Json.Linq.JToken token, out IGridControlValue value)
 		{
 			value = null;
-
-			value = GridControlLeBlenderValue.Parse(control, token);
-
+            
+            if (control.Editor.View == "/App_Plugins/LeBlender/editors/leblendereditor/LeBlendereditor.html")
+            {
+                value = GridControlLeBlenderValue.Parse(control, token);
+            }
+            
 			return value != null;
 		}
 
-		public bool ConvertEditorConfig(Skybrud.Umbraco.GridData.GridEditor editor, Newtonsoft.Json.Linq.JToken token, out IGridEditorConfig config)
+		public bool ConvertEditorConfig(GridEditor editor, Newtonsoft.Json.Linq.JToken token, out IGridEditorConfig config)
 		{
-			throw new NotImplementedException();
+            config = null;
+
+            if (editor.View == "/App_Plugins/LeBlender/editors/leblendereditor/LeBlendereditor.html")
+            {
+                config = GridEditorLeBlenderConfig.Parse(editor, token as JObject);
+            }
+
+            return config != null;
 		}
 
-		public bool GetControlWrapper(Skybrud.Umbraco.GridData.GridControl control, out Skybrud.Umbraco.GridData.Rendering.GridControlWrapper wrapper)
+		public bool GetControlWrapper(GridControl control, out GridControlWrapper wrapper)
 		{
-			throw new NotImplementedException();
+            wrapper = null;
+            
+            if (control.Editor.View == "/App_Plugins/LeBlender/editors/leblendereditor/LeBlendereditor.html")
+            {
+                if (control.Editor.Render == "/App_Plugins/LeBlender/editors/leblendereditor/views/Base.cshtml")
+                {
+                    //need to do this as we cant modify private properties of leblender editor
+                    JObject obj = JObject.FromObject(control);
+                    //overriding render view as default view won't know how to handle typed grid control
+                    obj["editor"]["render"] = "leblender";
+                    // need to do this because skybrud grid data has a Skybrud.Umbraco.GridData.Howdy class which always returns the original render view unless we change the alias to something it can't find
+                    obj["editor"]["alias"] = "wrapperconverted_" + obj["editor"]["alias"];
+
+                    JObject objCopy = JObject.FromObject(obj);
+                    control = GridControl.Parse(control.Area, objCopy);
+                }
+                wrapper = control.GetControlWrapper<GridControlLeBlenderValue>();
+            }
+
+            return wrapper != null;
 		}
 	}
 }

--- a/Render Examples/Views/Partials/TypedGrid/Bootstrap3.cshtml
+++ b/Render Examples/Views/Partials/TypedGrid/Bootstrap3.cshtml
@@ -1,0 +1,113 @@
+@using Newtonsoft.Json.Linq
+@using Skybrud.Umbraco.GridData
+@using Skybrud.Umbraco.GridData.Rendering
+
+@inherits UmbracoViewPage<GridDataModel>
+
+@if (Model != null && Model.Sections != null) {
+
+    bool oneColumn = Model.Sections.Length == 1;
+    
+    <div class="umb-grid">
+        @if (oneColumn) {
+            foreach (GridSection section in Model.Sections) {
+                <div class="grid-section">
+                    @foreach (GridRow row in section.Rows) {
+                        @RenderRow(row, true);
+                    }
+                </div>
+            }   
+        } else { 
+            <div class="container">
+                <div class="row clearfix">
+                    @foreach (GridSection section in Model.Sections) {
+                        <div class="grid-section">
+                            <div class="col-md-@(section.Grid) column">
+                                @foreach (GridRow row in section.Rows) {
+                                    @RenderRow(row, false)
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>   
+        }
+    </div>
+}
+
+@helper RenderRow(GridRow row, bool singleColumn) {
+    <div @RenderElementAttributes(row)>
+        <div class="row clearfix">
+            @foreach (GridArea area in row.Areas ) {
+            <div class="col-md-@area.Grid column">
+                <div @RenderElementAttributes(area)>
+                    @{
+                        foreach (GridControl control in area.Controls) {
+                            GridControlWrapper wrappedControl = WrapControl(control);
+                            RenderControl(wrappedControl);
+                        }
+                    }
+                </div>
+            </div>}
+        </div>
+    </div>
+}
+
+@helper RenderControl(GridControlWrapper wrappedControl)
+{
+    if (wrappedControl != null && wrappedControl.Editor != null && wrappedControl.Editor.View != null)
+    {
+        @Html.Partial("TypedGrid/Editors/Base", wrappedControl)
+    }
+}
+
+@functions {
+
+    public static GridControlWrapper WrapControl(GridControl control)
+    {
+        if (control == null)
+        {
+            return null;
+        }
+        return GridContext.Current.GetControlWrapper(control);
+    }
+    
+    public static MvcHtmlString RenderElementAttributes(GridRow row) {
+
+        List<string> attrs = new List<string>();
+
+        if (row.Config != null) {
+            attrs.AddRange(row.Config.Keys.Select(key => key + "='" + row.Config[key] + "'"));
+        }
+
+        if (row.Styles != null) {
+            List<string> cssVals = row.Styles.Keys.Select(key => key + ":" + row.Styles[key] + ";").ToList();
+            if (cssVals.Any()) {
+                attrs.Add("style='" + String.Join(" ", cssVals) + "'");
+            }
+        }
+
+        return new MvcHtmlString(string.Join(" ", attrs));
+    
+    }
+    
+    public static MvcHtmlString RenderElementAttributes(GridArea area) {
+        
+        List<string> attrs = new List<string>();
+
+		if (area.Config != null) {
+		    attrs.AddRange(area.Config.Keys.Select(key => key + "='" + area.Config[key] + "'"));
+		}
+
+        if (area.Styles != null) { 
+        	List<string> cssVals = area.Styles.Keys.Select(key => key + ":" + area.Styles[key] + ";").ToList();
+            if (cssVals.Any()) {
+            	attrs.Add("style='" + String.Join(" ", cssVals) + "'");
+			}
+        }
+            
+        return new MvcHtmlString(String.Join(" ", attrs));
+    
+    }
+
+}

--- a/Render Examples/Views/Partials/TypedGrid/Editors/Base.cshtml
+++ b/Render Examples/Views/Partials/TypedGrid/Editors/Base.cshtml
@@ -1,0 +1,31 @@
+﻿@using Skybrud.Umbraco.GridData
+@using Skybrud.Umbraco.GridData.Rendering
+@inherits UmbracoViewPage<GridControlWrapper>
+
+@functions {
+    public static string EditorView(GridControlWrapper contentItem)
+    {
+        string view = contentItem.Editor.Render ?? contentItem.Editor.View;
+        view = view.ToLower().Replace(".html", ".cshtml").Replace("/App_Plugins/Grid/", "/App_Plugins/TypedGrid/", StringComparison.InvariantCultureIgnoreCase);
+
+        if (!view.Contains("/"))
+        {
+            view = "TypedGrid/Editors/" + view;
+        }
+
+        return view;
+    }
+}
+@try
+{
+    
+    if (Model != null)
+    {
+        string editor = EditorView(Model);
+        @Html.Partial(editor, Model)
+    }
+}
+catch (Exception ex)
+{
+    <pre style="white-space: pre-wrap; color: white; border: 2px solid white; padding: 5px; margin-top: 10px; font-size: 11px;">@ex.ToString()</pre>
+}

--- a/Render Examples/Views/Partials/TypedGrid/Editors/leblender.cshtml
+++ b/Render Examples/Views/Partials/TypedGrid/Editors/leblender.cshtml
@@ -1,0 +1,41 @@
+﻿@using Skybrud.Umbraco.GridData.Rendering
+@using Skybrud.Umbraco.GridData.Values
+@using Skybrud.Umbraco.GridData.Config
+@using Opten.Umbraco.GridData.Config
+@using Opten.Umbraco.GridData.Values
+@using Lecoati.LeBlender.Extension
+@using Lecoati.LeBlender.Extension.Models
+
+@inherits UmbracoViewPage<GridControlWrapper<GridControlLeBlenderValue>>
+@try
+{
+    GridEditorLeBlenderConfig config = Model.Control.Editor.Config as GridEditorLeBlenderConfig;
+    string guid = config.Guid != null ? config.Guid : "";
+    LeBlenderModel blenderModel = Model.Value.Value;
+    var frontView = config.FrontView == null || String.IsNullOrEmpty(config.FrontView) ?
+        "" : (!config.FrontView.Contains("/") ? string.Format("/Views/Partials/TypedGrid/Editors/{0}.cshtml", config.FrontView) : config.FrontView);
+    string editorAlias = Model.Control.Editor.Alias;
+    ViewDataDictionary datas = new ViewDataDictionary(this.ViewData) { { "editorAlias", editorAlias }, { "frontView", frontView } };
+    int cacheExpiration = Helper.GetCacheExpiration(editorAlias);
+    if (cacheExpiration > 0 && Helper.IsFrontEnd())
+    {
+        <text>
+            @Html.LeBlenderCachedPartial("/App_Plugins/LeBlender/editors/leblendereditor/views/LeBlender.cshtml", blenderModel, cacheExpiration, guid, datas)
+        </text>
+    }
+    else
+    {
+        <text>
+            @Html.Partial("/App_Plugins/LeBlender/editors/leblendereditor/views/LeBlender.cshtml", blenderModel, datas)
+        </text>
+    }
+}
+catch (Exception ex)
+{
+    if (!Helper.IsFrontEnd())
+    {
+        <p class="red">Something went wrong with this editor, below is the exception detail:</p>
+    }
+    <p class="leblender-exception">@Helper.GetInnerMessage(ex)</p>
+}
+

--- a/Values/GridControlLeBlenderValue.cs
+++ b/Values/GridControlLeBlenderValue.cs
@@ -3,8 +3,10 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Skybrud.Umbraco.GridData;
 using Skybrud.Umbraco.GridData.Interfaces;
+using Skybrud.Umbraco.GridData.Json;
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -12,7 +14,7 @@ using System.Threading.Tasks;
 namespace Opten.Umbraco.GridData.Values
 {
 	[JsonConverter(typeof(LeBlenderModelMatchingConverter))]
-	public class GridControlLeBlenderValue : IGridControlValue
+    public class GridControlLeBlenderValue : IGridControlValue
 	{
 		#region Properties
 
@@ -24,26 +26,36 @@ namespace Opten.Umbraco.GridData.Values
 		/// <summary>
 		/// Gets a reference to the underlying instance of <code>JToken</code>.
 		/// </summary>
-		[JsonIgnore]
-		public JToken JToken { get; private set; }
+        [JsonIgnore]
+        public JToken JToken { get; private set; }
+
 
 		/// <summary>
 		/// Gets a string representing the value.
 		/// </summary>
 		[JsonProperty("value")]
-		public LeBlenderValue Value;
+        public LeBlenderModel Value { get; set; }
+
+
 
 		#endregion
 
 		#region Constructors
 
-		protected GridControlLeBlenderValue(GridControl control, JToken token)
-		{
-			Control = control;
-			JToken = token;
-			Value = token.Value<LeBlenderValue>();
-			
-		}
+        protected GridControlLeBlenderValue(GridControl control, JToken token)
+        {
+            Control = control;
+            JToken = token;
+            IEnumerable<LeBlenderValue> LeBlenderValueItems = JsonConvert.DeserializeObject<IEnumerable<LeBlenderValue>>(token.ToString());
+            if (LeBlenderValueItems != null)
+            {
+                Value = new LeBlenderModel() { Items = LeBlenderValueItems };
+            }
+            else
+            {
+                Value = new LeBlenderModel();
+            }
+        }
 
 		#endregion
 
@@ -54,10 +66,10 @@ namespace Opten.Umbraco.GridData.Values
 		/// </summary>
 		/// <param name="control">The parent control.</param>
 		/// <param name="token">The instance of <code>JToken</code> to be parsed.</param>
-		public static GridControlLeBlenderValue Parse(GridControl control, JToken token)
+        public static GridControlLeBlenderValue Parse(GridControl control, JToken token)
 		{
 			if (token == null) return null;
-			return new GridControlLeBlenderValue(control, token);
+            return new GridControlLeBlenderValue(control, token);
 		}
 		
 		#endregion


### PR DESCRIPTION
Changes made ensure converter only runs for leblender grid controls,
Added config converter and means of re-routing render to a view suitable
for typed models